### PR TITLE
Improve button color contrast (WCAG 2.1 AA)

### DIFF
--- a/build/style-index-rtl.css
+++ b/build/style-index-rtl.css
@@ -71,7 +71,7 @@ abbr[title] {
   border-bottom: none; /* 1 */
   text-decoration: underline; /* 2 */
   -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted; /* 2 */
+  text-decoration: underline dotted; /* 2 */
 }
 /**
  * Add the correct font weight in Chrome, Edge, and Safari.
@@ -142,7 +142,8 @@ textarea {
  * 1. Show the overflow in Edge.
  */
 button,
-input { /* 1 */
+input {
+  /* 1 */
   overflow: visible;
 }
 /**
@@ -150,7 +151,8 @@ input { /* 1 */
  * 1. Remove the inheritance of text transform in Firefox.
  */
 button,
-select { /* 1 */
+select {
+  /* 1 */
   text-transform: none;
 }
 /**
@@ -279,16 +281,70 @@ template {
 [hidden] {
   display: none;
 }
-.glide{position:relative;width:100%;box-sizing:border-box}
-.glide *{box-sizing:inherit}
-.glide__track{overflow:hidden}
-.glide__slides{position:relative;width:100%;list-style:none;backface-visibility:hidden;transform-style:preserve-3d;touch-action:pan-Y;overflow:hidden;margin:0;padding:0;white-space:nowrap;display:flex;flex-wrap:nowrap;will-change:transform}
-.glide__slides--dragging{-webkit-user-select:none;-moz-user-select:none;user-select:none}
-.glide__slide{width:100%;height:100%;flex-shrink:0;white-space:normal;-webkit-user-select:none;-moz-user-select:none;user-select:none;-webkit-touch-callout:none;-webkit-tap-highlight-color:transparent}
-.glide__slide a{-webkit-user-select:none;user-select:none;-webkit-user-drag:none;-moz-user-select:none;-ms-user-select:none}
-.glide__arrows{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;user-select:none}
-.glide__bullets{-webkit-touch-callout:none;-webkit-user-select:none;-moz-user-select:none;user-select:none}
-.glide--rtl{direction:ltr}
+.glide {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+}
+.glide * {
+  box-sizing: inherit;
+}
+.glide__track {
+  overflow: hidden;
+}
+.glide__slides {
+  position: relative;
+  width: 100%;
+  list-style: none;
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+  touch-action: pan-Y;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
+  display: flex;
+  flex-wrap: nowrap;
+  will-change: transform;
+}
+.glide__slides--dragging {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.glide__slide {
+  width: 100%;
+  height: 100%;
+  flex-shrink: 0;
+  white-space: normal;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.glide__slide a {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-user-drag: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+.glide__arrows {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.glide__bullets {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+.glide--rtl {
+  direction: ltr;
+}
 /* SASS and Global'ish Stuff */
 body {
   color: #8c6a5e;
@@ -672,12 +728,12 @@ li {
   transform: scale(0.2);
   opacity: 0;
 }
-.like-box[data-exists=yes] .fa-heart {
+.like-box[data-exists="yes"] .fa-heart {
   transform: scale(1);
   visibility: visible;
   opacity: 1;
 }
-.like-box[data-exists=yes] .fa-heart-o {
+.like-box[data-exists="yes"] .fa-heart-o {
   visibility: hidden;
   opacity: 0;
 }
@@ -685,7 +741,11 @@ li {
 body.login .button-primary {
   background-color: #ee826c;
   border-color: rgb(234.4134146341, 103.6280487805, 76.9865853659);
-  text-shadow: 0 -1px 1px rgb(232.6201219512, 90.4420731707, 61.4798780488), -1px 0 1px rgb(232.6201219512, 90.4420731707, 61.4798780488), 0 1px 1px rgb(232.6201219512, 90.4420731707, 61.4798780488), 1px 0 1px rgb(232.6201219512, 90.4420731707, 61.4798780488);
+  text-shadow:
+    0 -1px 1px rgb(232.6201219512, 90.4420731707, 61.4798780488),
+    -1px 0 1px rgb(232.6201219512, 90.4420731707, 61.4798780488),
+    0 1px 1px rgb(232.6201219512, 90.4420731707, 61.4798780488),
+    1px 0 1px rgb(232.6201219512, 90.4420731707, 61.4798780488);
   box-shadow: 0 1px 0 rgb(230.8268292683, 77.256097561, 45.9731707317);
 }
 body.login .button-primary:active,
@@ -693,7 +753,11 @@ body.login .button-primary:focus,
 body.login .button-primary:hover {
   background-color: rgb(234.7720731707, 106.2652439024, 80.0879268293);
   border-color: #ee826c;
-  text-shadow: 0 -1px 1px rgb(230.8268292683, 77.256097561, 45.9731707317), -1px 0 1px rgb(230.8268292683, 77.256097561, 45.9731707317), 0 1px 1px rgb(230.8268292683, 77.256097561, 45.9731707317), 1px 0 1px rgb(230.8268292683, 77.256097561, 45.9731707317);
+  text-shadow:
+    0 -1px 1px rgb(230.8268292683, 77.256097561, 45.9731707317),
+    -1px 0 1px rgb(230.8268292683, 77.256097561, 45.9731707317),
+    0 1px 1px rgb(230.8268292683, 77.256097561, 45.9731707317),
+    1px 0 1px rgb(230.8268292683, 77.256097561, 45.9731707317);
   box-shadow: 0 1px 0 rgb(229.0335365854, 64.0701219512, 30.4664634146);
 }
 body.login {
@@ -956,7 +1020,10 @@ body.login {
   padding-top: 58px;
   opacity: 0;
   transform: translateY(-20%);
-  transition: opacity 0.3s ease-out, visibility 0.3s ease-out, transform 0.3s ease-out;
+  transition:
+    opacity 0.3s ease-out,
+    visibility 0.3s ease-out,
+    transform 0.3s ease-out;
   padding-bottom: 20px;
 }
 .site-header__menu--active {
@@ -1322,7 +1389,10 @@ body.login {
   visibility: hidden;
   opacity: 0;
   transform: scale(1.09);
-  transition: opacity 0.3s, transform 0.3s, visibility 0.3s;
+  transition:
+    opacity 0.3s,
+    transform 0.3s,
+    visibility 0.3s;
   box-sizing: border-box;
 }
 .search-overlay p {
@@ -1439,7 +1509,9 @@ body.admin-bar .search-overlay {
 }
 .professor-card__image {
   display: block;
-  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+  transition:
+    opacity 0.3s ease-out,
+    transform 0.3s ease-out;
 }
 .professor-card:hover .professor-card__image {
   opacity: 0.8;
@@ -1628,7 +1700,7 @@ body.admin-bar .search-overlay {
   right: 0;
   position: absolute;
   padding: 14px 0 11px 0;
-  color: #FFF;
+  color: #fff;
   border-radius: 50%;
   background-color: #a9c8b9;
   width: 80px;
@@ -1685,7 +1757,8 @@ body.admin-bar .search-overlay {
 .page-links li:first-child {
   border-top: none;
 }
-.page-links__active, .page-links .current_page_item {
+.page-links__active,
+.page-links .current_page_item {
   text-align: center;
   background-color: rgb(245.9934230769, 232.7592692308, 216.2165769231);
   color: #a9c8b9;
@@ -1716,7 +1789,7 @@ body.admin-bar .search-overlay {
 .link-list li {
   padding: 1rem 0;
   font-size: 1.5rem;
-  border-bottom: 1px dotted #DEDEDE;
+  border-bottom: 1px dotted #dedede;
 }
 .search-overlay .link-list li {
   font-size: 1.3rem;
@@ -1772,7 +1845,7 @@ body.admin-bar .search-overlay {
   background-color: rgb(153.4468085106, 190.0531914894, 172.3404255319);
 }
 .post-item {
-  border-bottom: 1px dotted #DEDEDE;
+  border-bottom: 1px dotted #dedede;
   padding-bottom: 1.7rem;
   margin-bottom: 1.7rem;
 }
@@ -1803,7 +1876,7 @@ body.admin-bar .search-overlay {
   width: 100%;
   height: 100%;
   -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   display: block;
 }
 /* Centered overlay content */
@@ -1907,7 +1980,10 @@ body.admin-bar .search-overlay {
   padding: 0.25rem 0.6rem;
   font-size: 0.85rem;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
 }
 .az-filter__btn.is-active {
   background: #222;
@@ -1968,7 +2044,9 @@ body.admin-bar .search-overlay {
 .scroll-to-hero-btn:focus,
 .scroll-to-hero-btn:focus-visible {
   outline: none !important;
-  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.45), 0 8px 20px rgba(0, 0, 0, 0.18);
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.45),
+    0 8px 20px rgba(0, 0, 0, 0.18);
 }
 /* Firefox inner focus fix */
 .scroll-to-hero-btn::-moz-focus-inner {
@@ -1989,7 +2067,9 @@ body.admin-bar .search-overlay {
   background: rgba(0, 0, 0, 0.35);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25), 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.25),
+    0 3px 6px rgba(0, 0, 0, 0.2);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2004,12 +2084,16 @@ body.admin-bar .search-overlay {
 .locale-hero .swiper-button-next:hover,
 .locale-hero .swiper-button-prev:hover {
   transform: translateY(-1px);
-  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.3), 0 4px 8px rgba(0, 0, 0, 0.25);
+  box-shadow:
+    0 10px 22px rgba(0, 0, 0, 0.3),
+    0 4px 8px rgba(0, 0, 0, 0.25);
 }
 .locale-hero .swiper-button-next:active,
 .locale-hero .swiper-button-prev:active {
   transform: translateY(1px) scale(0.97);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3), inset 0 2px 4px rgba(255, 255, 255, 0.15);
+  box-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.3),
+    inset 0 2px 4px rgba(255, 255, 255, 0.15);
 }
 /* ================================
    Child Locale Banners (Single Locale)
@@ -2036,7 +2120,9 @@ body.admin-bar .search-overlay {
   text-decoration: none;
   color: #fff;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
 }
 /* background image layer */
 .child-banner__bg {
@@ -2101,8 +2187,12 @@ body.admin-bar .search-overlay {
   overflow: hidden;
   position: relative;
   text-decoration: none;
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.16), 0 18px 30px rgba(0, 0, 0, 0.1);
-  transition: transform 0.35s ease, box-shadow 0.35s ease;
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.16),
+    0 18px 30px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.35s ease,
+    box-shadow 0.35s ease;
   background: #000;
 }
 /* Fixed card height like your CodePen */
@@ -2116,7 +2206,7 @@ body.admin-bar .search-overlay {
   width: 100%;
   height: 100%;
   -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   display: block;
   transition: transform 0.6s ease;
 }
@@ -2129,7 +2219,9 @@ body.admin-bar .search-overlay {
   background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.1));
   opacity: 0;
   transform: translateY(16px);
-  transition: opacity 0.35s ease, transform 0.35s ease;
+  transition:
+    opacity 0.35s ease,
+    transform 0.35s ease;
 }
 .pastry-card__title {
   font-size: 1.1rem;
@@ -2144,7 +2236,9 @@ body.admin-bar .search-overlay {
 }
 .pastry-card__link:hover {
   transform: translateY(-8px);
-  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.22), 0 22px 40px rgba(0, 0, 0, 0.14);
+  box-shadow:
+    0 40px 80px rgba(0, 0, 0, 0.22),
+    0 22px 40px rgba(0, 0, 0, 0.14);
 }
 .pastry-card__link:hover .pastry-card__image {
   transform: scale(1.06);
@@ -2152,4 +2246,36 @@ body.admin-bar .search-overlay {
 .pastry-card__link:hover .pastry-card__overlay {
   opacity: 1;
   transform: translateY(0);
+}
+/* === A11y hotfix: button contrast (WCAG 2.1 AA) === */
+.btn--blue,
+.btn--orange,
+.btn--dark-orange {
+  color: #fff;
+}
+
+.btn--blue {
+  background-color: #5e7d6e;
+}
+.btn--orange {
+  background-color: #b75f14;
+}
+.btn--dark-orange {
+  background-color: #8f3e2d;
+}
+
+.btn--blue:hover,
+.btn--orange:hover,
+.btn--dark-orange:hover,
+.btn--blue:focus-visible,
+.btn--orange:focus-visible,
+.btn--dark-orange:focus-visible {
+  filter: brightness(0.9);
+}
+
+.btn--blue:focus-visible,
+.btn--orange:focus-visible,
+.btn--dark-orange:focus-visible {
+  outline: 3px solid #000;
+  outline-offset: 3px;
 }

--- a/build/style-index.css
+++ b/build/style-index.css
@@ -2507,4 +2507,31 @@ body.admin-bar .search-overlay {
   font-size: 18px !important;
   font-weight: bold;
 }
+/* === A11y hotfix: button contrast (WCAG 2.1 AA) === */
+.btn--blue,
+.btn--orange,
+.btn--dark-orange {
+  color: #fff;
+}
+
+.btn--blue { background-color: #5e7d6e; }
+.btn--orange { background-color: #b75f14; }
+.btn--dark-orange { background-color: #8f3e2d; }
+
+.btn--blue:hover,
+.btn--orange:hover,
+.btn--dark-orange:hover,
+.btn--blue:focus-visible,
+.btn--orange:focus-visible,
+.btn--dark-orange:focus-visible {
+  filter: brightness(0.9);
+}
+
+.btn--blue:focus-visible,
+.btn--orange:focus-visible,
+.btn--dark-orange:focus-visible {
+  outline: 3px solid #000;
+  outline-offset: 3px;
+}
+
 /*# sourceMappingURL=style-index.css.map*/

--- a/docs/accessibility-audit.md
+++ b/docs/accessibility-audit.md
@@ -61,7 +61,7 @@ Findings were grouped by recurring patterns rather than individual instances.
 
 | Issue | WCAG | Scope | Status |
 |------|------|-------|--------|
-| Button color contrast (all button variants) | 1.4.3 | Theme | Open |
+| Button color contrast (all button variants) | 1.4.3 | Theme | Open (#1)|
 | Search input missing label | 1.3.1 / 4.1.2 | Theme | Open |
 | Slider bullets missing accessible names | 4.1.2 | Theme / Plugin | Open |
 | Icon-only links missing accessible names | 4.1.2 | Theme | Open |

--- a/docs/pa11y-home-after-button-contrast.txt
+++ b/docs/pa11y-home-after-button-contrast.txt
@@ -1,0 +1,69 @@
+
+Welcome to Pa11y
+
+ > Running Pa11y on URL http://universo-da-docura
+
+Results for URL: http://universo-da-docura/
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > header > div > a
+   └── <a href="http://universo-da-docura/search" class="site-header__search-trigger js-search-trigger"> <i class="fa fa-search" ...</a>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > header > div > div > div > a:nth-child(3)
+   └── <a href="http://universo-da-docura/search" class="search-trigger js-search-trigger"> <i class="fa fa-sear...</a>
+
+ • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text colour to #080808.
+   ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
+   ├── html > body > div:nth-child(3) > div:nth-child(2) > div > div:nth-child(2) > div > p > a
+   └── <a href="http://universo-da-docura/exploring-tea/" class="nu gray">Read more</a>
+
+ • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text colour to #080808.
+   ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
+   ├── html > body > div:nth-child(3) > div:nth-child(2) > div > div:nth-child(3) > div > p > a
+   └── <a href="http://universo-da-docura/creating-fictional-chefs/" class="nu gray">Read more</a>
+
+ • Error: This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name
+   ├── html > body > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(1)
+   └── <button class="slider__bullet glide__bullet glide__bullet--active" data-glide-dir="=0"></button>
+
+ • Error: This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name
+   ├── html > body > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(2)
+   └── <button class="slider__bullet glide__bullet" data-glide-dir="=1"></button>
+
+ • Error: This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name
+   ├── html > body > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(3)
+   └── <button class="slider__bullet glide__bullet" data-glide-dir="=2"></button>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > footer > div > div > div:nth-child(3) > nav > ul > li:nth-child(1) > a
+   └── <a href="#" class="social-color-facebook"> <i class="fa f...</a>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > footer > div > div > div:nth-child(3) > nav > ul > li:nth-child(2) > a
+   └── <a href="#" class="social-color-linkedin"> <i class="fa f...</a>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > footer > div > div > div:nth-child(3) > nav > ul > li:nth-child(3) > a
+   └── <a href="#" class="social-color-instagram"> <i class="fa f...</a>
+
+ • Error: This textinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputText.Name
+   ├── #search-term
+   └── <input type="text" class="search-term" placeholder="Search desserts, locales, journal…" id="search-term">
+
+ • Error: This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.
+   ├── WCAG2AA.Principle1.Guideline1_3.1_3_1.F68
+   ├── #search-term
+   └── <input type="text" class="search-term" placeholder="Search desserts, locales, journal…" id="search-term">
+
+12 Errors
+

--- a/docs/pa11y-home-after.txt
+++ b/docs/pa11y-home-after.txt
@@ -15,12 +15,12 @@ Results for URL: http://universo-da-docura/
    ├── html > body > header > div > div > div > a:nth-child(3)
    └── <a href="http://universo-da-docura/search" class="search-trigger js-search-trigger"> <i class="fa fa-sear...</a>
 
- • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text colour to #080808.
+ • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text color to #080808.
    ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
    ├── html > body > div:nth-child(3) > div:nth-child(2) > div > div:nth-child(2) > div > p > a
    └── <a href="http://universo-da-docura/exploring-tea/" class="nu gray">Read more</a>
 
- • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text colour to #080808.
+ • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text color to #080808.
    ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
    ├── html > body > div:nth-child(3) > div:nth-child(2) > div > div:nth-child(3) > div > p > a
    └── <a href="http://universo-da-docura/creating-fictional-chefs/" class="nu gray">Read more</a>
@@ -66,4 +66,3 @@ Results for URL: http://universo-da-docura/
    └── <input type="text" class="search-term" placeholder="Search desserts, locales, journal…" id="search-term">
 
 12 Errors
-

--- a/docs/pa11y-home-after.txt
+++ b/docs/pa11y-home-after.txt
@@ -1,0 +1,69 @@
+
+Welcome to Pa11y
+
+ > Running Pa11y on URL http://universo-da-docura
+
+Results for URL: http://universo-da-docura/
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > header > div > a
+   └── <a href="http://universo-da-docura/search" class="site-header__search-trigger js-search-trigger"> <i class="fa fa-search" ...</a>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > header > div > div > div > a:nth-child(3)
+   └── <a href="http://universo-da-docura/search" class="search-trigger js-search-trigger"> <i class="fa fa-sear...</a>
+
+ • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text colour to #080808.
+   ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
+   ├── html > body > div:nth-child(3) > div:nth-child(2) > div > div:nth-child(2) > div > p > a
+   └── <a href="http://universo-da-docura/exploring-tea/" class="nu gray">Read more</a>
+
+ • Error: This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 2.72:1. Recommendation:  change text colour to #080808.
+   ├── WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail
+   ├── html > body > div:nth-child(3) > div:nth-child(2) > div > div:nth-child(3) > div > p > a
+   └── <a href="http://universo-da-docura/creating-fictional-chefs/" class="nu gray">Read more</a>
+
+ • Error: This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name
+   ├── html > body > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(1)
+   └── <button class="slider__bullet glide__bullet glide__bullet--active" data-glide-dir="=0"></button>
+
+ • Error: This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name
+   ├── html > body > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(2)
+   └── <button class="slider__bullet glide__bullet" data-glide-dir="=1"></button>
+
+ • Error: This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name
+   ├── html > body > div:nth-child(4) > div > div:nth-child(2) > button:nth-child(3)
+   └── <button class="slider__bullet glide__bullet" data-glide-dir="=2"></button>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > footer > div > div > div:nth-child(3) > nav > ul > li:nth-child(1) > a
+   └── <a href="#" class="social-color-facebook"> <i class="fa f...</a>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > footer > div > div > div:nth-child(3) > nav > ul > li:nth-child(2) > a
+   └── <a href="#" class="social-color-linkedin"> <i class="fa f...</a>
+
+ • Error: Anchor element found with a valid href attribute, but no link content has been supplied.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent
+   ├── html > body > footer > div > div > div:nth-child(3) > nav > ul > li:nth-child(3) > a
+   └── <a href="#" class="social-color-instagram"> <i class="fa f...</a>
+
+ • Error: This textinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.
+   ├── WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputText.Name
+   ├── #search-term
+   └── <input type="text" class="search-term" placeholder="Search desserts, locales, journal…" id="search-term">
+
+ • Error: This form field should be labelled in some way. Use the label element (either with a "for" attribute or wrapped around the form field), or "title", "aria-label" or "aria-labelledby" attributes as appropriate.
+   ├── WCAG2AA.Principle1.Guideline1_3.1_3_1.F68
+   ├── #search-term
+   └── <input type="text" class="search-term" placeholder="Search desserts, locales, journal…" id="search-term">
+
+12 Errors
+


### PR DESCRIPTION
Fixes #1

### What changed
- Updated button colors in compiled theme CSS to meet WCAG 2.1 AA contrast requirements
- Added focus-visible outlines for keyboard users
- Re-ran Pa11y: errors reduced from 23 → 12 (remaining errors tracked separately)

### Verification
- Pa11y output saved: `docs/pa11y-home-after-button-contrast.txt`
- Manual spot-check: buttons readable; focus styles visible with keyboard navigation
